### PR TITLE
updated docs requirements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ src/nbi.egg-info/
 \#*
 **/__pycache__
 *~
+
+*.DS_Store
+
+# Sphinx documentation
+docs/_build/

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -123,4 +123,4 @@ Work on this project was supported by the `National Science Foundation award #22
 
 .. raw:: html
 
-   <center><img src="https://www.nsf.gov/policies/images/NSF_Official_logo.svg" width="10%"></center>
+   <center><img src="https://new.nsf.gov/themes/custom/nsf_theme/components/images/logo/logo-desktop.svg" width="30%"></center>

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -11,3 +11,4 @@ joblib
 pytest
 tqdm
 multiprocess
+wandb


### PR DESCRIPTION
fixes #34 by adding wandb to docs/requirements. Also modifies .gitignore to exclude files generated when building the docs locally, and replaces an outdated link to the NSF logo in docs/README.rst to match the one in README.md