### PR TITLE
Fix: Handle zero valid samples in importance_reweight to avoid ValueError crash

### DIFF
--- a/src/nbi/engine.py
+++ b/src/nbi/engine.py
@@ -633,6 +633,10 @@ class NBI:
         log_weights = loglike + logprior - logproposal
 
         bad = np.isnan(log_weights) + np.isinf(log_weights)
+        valid_weights = log_weights[~bad]
+        if len(valid_weights) == 0:
+            print("All log weights are NaN or Inf — skipping this round!")
+            return np.zeros_like(log_weights)
         log_weights -= log_weights[~bad].max()
 
         weights = np.exp(log_weights)


### PR DESCRIPTION
### Summary
This PR adds a guard in `importance_reweight` to handle cases where all log weights are NaN or Inf, which previously caused a crash at `.max()`. If no valid samples are found, the function now returns zero weights as a safe fallback.

### What this fixes
Previously, if all samples were invalid (e.g., failed simulations, out-of-support prior samples), the code would hit:
```python
log_weights -= log_weights[~bad].max()
```

leading to:
```pgsql
ValueError: zero-size array to reduction operation maximum which has no identity
```

### Changes

- Added a check for empty valid samples after masking out NaN/Inf log weights.
- If no valid samples are found, zero weights are returned to prevent a crash.
- Added a warning printout for diagnostics.

### Related Issue
Fixes #39 

### Notes
This is a minimal fix to avoid the crash. A future enhancement could include diagnostics when invalid samples dominate, and possibly resampling strategies.


